### PR TITLE
cs: remove stray ")" from mistral streamed response example in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -96,7 +96,7 @@ $params = [
         'safe_prompt' => false,
         'random_seed' => null
 ];
-foreach ($client->chatStream($messages, $params)) as $chunk) {
+foreach ($client->chatStream($messages, $params) as $chunk) {
     echo $chunk->getChunk();
 }
 ```


### PR DESCRIPTION
### Summary
This PR fixes a small typo in the README.md where an extra closing parenthesis ) was present in the streamed response code example. Removing it improves readability and prevents potential confusion when copying the example.

### Changes
Removed stray ) from the streamed response example in the README.

### Motivation
Accurate and clean documentation is essential for a smooth developer experience, especially when it comes to usage examples.