### PR TITLE
Require php >= 8.3 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "test": "phpunit"
     },
     "require": {
+        "php": ">=8.3",
         "symfony/http-client": "^6.4 || ^7.0",
         "knplabs/php-json-schema": "^0.1.0"
     }


### PR DESCRIPTION
Summary
This PR adds a requirement for php >= 8.3 in composer.json so you can't install the package if your php version is anterior

Changes
Add "php": ">=8.3", requirement in composer.json

Motivation
I tried using the package without seeing that it needed php 8.3 and got a syntax error in 8.2 from the typed constants in MistralClient. With that change you'll be warned by composer that the package is incompatible with your php version