### PR TITLE
fix nullable type deprecation in MistralClient constructor

### DIFF
--- a/src/MistralClient.php
+++ b/src/MistralClient.php
@@ -55,7 +55,7 @@ class MistralClient
     private HttpClientInterface $httpClient;
     private null|int|float $timeout = null; // null = default_socket_timeout
 
-    public function __construct(string $apiKey, string $url = self::ENDPOINT, int|float $timeout = null)
+    public function __construct(string $apiKey, string $url = self::ENDPOINT, int|float|null $timeout = null)
     {
         $this->setTimeout($timeout);
         $this->httpClient = new RetryableHttpClient(


### PR DESCRIPTION
Quick fix for this deprecation in php 8.4 : 
`Deprecated: Partitech\PhpMistral\MistralClient::__construct(): Implicitly marking parameter $timeout as nullable is deprecated, the explicit nullable type must be used instead in /var/www/vendor/partitech/php-mistral/src/MistralClient.php on line 58`