### PR TITLE
Allow args when config is url based

### DIFF
--- a/src/Mcp/McpServerConfig.php
+++ b/src/Mcp/McpServerConfig.php
@@ -21,8 +21,14 @@ class McpServerConfig implements JsonSerializable
     {
         $this->name = $name;
 
-        if (isset($definition['url'])) {
+        if (isset($definition['url'], $definition['args'])) {
             $this->url = $definition['url'];
+            $this->args = array_map(function ($arg) use ($variables) {
+                return preg_replace_callback('/\$\{([^}]+)\}/', function ($matches) use ($variables) {
+                    $key = $matches[1];
+                    return $variables[$key] ?? $matches[0];
+                }, $arg);
+            }, $definition['args']);
         }
 
         if (isset($definition['command'], $definition['args'])) {


### PR DESCRIPTION
It seems args are sometimes needed when using a url based mcp server, so this adds support for it.

#49 Required to set Authorization header