### PR TITLE
Update MistralConversation.php $model error

### DIFF
--- a/src/Clients/Mistral/MistralConversation.php
+++ b/src/Clients/Mistral/MistralConversation.php
@@ -29,7 +29,7 @@ class MistralConversation
     private ?string           $name;
     private ?string           $description;
     private ?string           $object;
-    private string            $model;
+    private ?string            $model;
     private string $handoffExecution = 'server';
     private DateTimeImmutable $createdAt;
     private DateTimeImmutable $updatedAt;
@@ -68,7 +68,7 @@ class MistralConversation
         $conv->name        = $data['name'] ?? null;
         $conv->description = $data['description'] ?? null;
         $conv->object      = $data['object'] ?? null;
-        $conv->model       = $data['model'];
+        $conv->model       = $data['model'] ?? null;
         $conv->createdAt   = new DateTimeImmutable($data['created_at']);
         $conv->updatedAt   = new DateTimeImmutable($data['updated_at']);
         return $conv;


### PR DESCRIPTION
I obtained an error message with model not nullable when I tried to view discussions:

```
$client = new MistralConversationClient(apiKey: IA_API_KEY);
$conversations = $client->listConversations(page: 0, pageSize: 100);

foreach ($conversations->getIterator() as $index => $conversation) {
		
		echo ("<b>" . $index . " " . $conversation->getId() . "</b><br />\n");
		
		$messages = $client->getConversationMessages($conversation)->getMessages();
		
		foreach ($messages->getIterator() as $imsg => $message) {
			
			if ($message->getRole()==="user") {
				echo ("<i>User: " . $message->getContent() . "</i><br />\n");
			}
			else {
				echo ("Resp: " . $message->getContent() . "<br />\n");
			}
		
		}
		
		echo ("<br />\n");
		
	}
```