### PR TITLE
Handle null content in addAssistantMessage method

### DIFF
--- a/src/Messages.php
+++ b/src/Messages.php
@@ -128,7 +128,7 @@ class Messages
     {
         $message = new Message($this->clientType);
         $message->setRole(self::ROLE_ASSISTANT);
-        $message->setContent(trim($content));
+        $message->setContent(trim($content ?? ''));
         $message->setToolCalls($toolCalls);
         $this->addMessage($message);
         return $this;


### PR DESCRIPTION
trim(): Passing null to parameter #1 ($string) of type string is deprecated in /app/vendor/partitech/php-mistral/src/Messages.php on line 136

Trim will also throw an error if $content is actually an array