### PR TITLE
fix: Add default values to uninitialized typed properties in Response class

### DIFF
--- a/src/Clients/Response.php
+++ b/src/Clients/Response.php
@@ -25,12 +25,12 @@ class Response
 
     private ?string     $id     = null;
     private string      $object = 'chat.completion';
-    private int         $created;
-    private string      $model;
-    private string      $fingerPrint;
+    private int         $created = 0;
+    private string      $model = '';
+    private string      $fingerPrint = '';
     private ArrayObject $choices;
-    private ?array      $pages;
-    private ?string      $clientType;
+    private ?array      $pages = null;
+    private ?string     $clientType;
 
     private array $usage = [];
 


### PR DESCRIPTION
Properties like `$created`, `$model`, `$fingerPrint`, and `$pages` were declared without defaults, causing "must not be accessed before initialization" errors when accessing fields not present in certain API response types.

For example:
- `$pages` is only in OCR responses → errors on chat
- `$created` is not in OCR responses → errors on OCR

Fixes #80